### PR TITLE
Kindly review: Updated generator result according to ruby 1.9 changed the hash format from {:id => "text" } to {id: "test"}

### DIFF
--- a/lib/selenium_fury/selenium_web_driver/page_generator.rb
+++ b/lib/selenium_fury/selenium_web_driver/page_generator.rb
@@ -24,7 +24,7 @@ module SeleniumFury
         result += "found (#{page_object_attributes.length} elements)\n"
         result += "class #{class_name} < PageObject\n"
         page_object_attributes.keys.sort.each do |attribute_name|
-          result += "\t\telement :#{attribute_name}, {:#{page_object_attributes[attribute_name].keys[0]} => \"#{page_object_attributes[attribute_name].values[0]}\"}\n"
+          result += "\t\telement :#{attribute_name}, {#{page_object_attributes[attribute_name].keys[0]}: \"#{page_object_attributes[attribute_name].values[0]}\"}\n"
         end
         result += "\n\nend"
         $stdout.puts result

--- a/spec/selenium_web_driver/page_generator_spec.rb
+++ b/spec/selenium_web_driver/page_generator_spec.rb
@@ -4,7 +4,7 @@ describe SeleniumFury::SeleniumWebDriver::PageGenerator do
     launch_web_driver TEST_PAGE_URL
     result = generate(driver)
     result.should include 'found (15 elements)'
-    result.should include 'element :form, {:id => "form"}'
+    result.should include 'element :form, {id: "form"}'
   end
   it "should return a TestPage page object" do
     launch_web_driver TEST_PAGE_URL


### PR DESCRIPTION
...rom {:id => "text" } to {id: "test"}
