### PR TITLE
Adding #double_click and #double_click!

### DIFF
--- a/lib/selenium_fury/selenium_web_driver/generic_elements/generic_element_helpers.rb
+++ b/lib/selenium_fury/selenium_web_driver/generic_elements/generic_element_helpers.rb
@@ -30,6 +30,18 @@ module GenericElementHelpers
     @driver.action.move_to(el).perform
   end
 
+  def double_click
+    @driver.action.double_click(el).perform
+  end
+
+  def double_click!
+    el.click
+  rescue Exception => e
+    puts "Encountered #{e.class} trying to click element at #{self.location}"
+  ensure
+    el.click
+  end
+
   # Use any methods from WebDriverElement not present
   def method_missing method_sym, *args
     if el.respond_to?(method_sym)

--- a/spec/selenium_fury/selenium_web_driver/generic_elements/generic_elements_spec.rb
+++ b/spec/selenium_fury/selenium_web_driver/generic_elements/generic_elements_spec.rb
@@ -59,6 +59,26 @@ describe PageObject do
       test_page.input_button_element.value.should == 'Click me'
     end
 
+    describe '#double_click' do
+      it 'should double-click the given element' do
+        status_before = test_page.input_doubleclick['readonly']
+        test_page.input_doubleclick.double_click
+        status_after = test_page.input_doubleclick['readonly']
+
+        status_after.should_not == status_before
+      end
+    end
+
+    describe '#double_click!' do
+      it 'should simply invoke click twice, ignoring any errors encountered on the initial click' do
+        status_before = test_page.input_doubleclick['readonly']
+        test_page.input_doubleclick.double_click!
+        status_after = test_page.input_doubleclick['readonly']
+
+        status_after.should == status_before # Because two #click()'s does not equal one #dblclick()
+      end
+    end
+
     it 'When there is more than one element with the provided locator, it should return an array of all of them' do
       test_page.listings_element.list.should be_an Array
       test_page.listings_element.list[0].should be_an Selenium::WebDriver::Element

--- a/spec/test_page/test_page.html
+++ b/spec/test_page/test_page.html
@@ -63,6 +63,8 @@
     <label for="input_text">Text</label>
     <input id="input_text" type="text"/>
     <br/>
+    <label for="input_requires_double_click">This input requires double click</label>
+    <input id="input_requires_double_click" type="text" value="asdf" readonly="true" ondblclick="this.readOnly='';">
     <fieldset>
         <legend>Input test:</legend>
         <label for="input_message">Message Text:</label>

--- a/spec/test_page/test_page.rb
+++ b/spec/test_page/test_page.rb
@@ -26,6 +26,7 @@ class TestPage < PageObject
   generic_element       :fieldset_element, {css: 'fieldset'}
   generic_element       :listings_element, {css: 'li.listing'}
   generic_element       :not_visible_element, {id: 'not_visible'}
+  generic_element       :input_doubleclick, {:id => 'input_requires_double_click'}
 
   checkbox_element      :input_checkbox_element, {id: 'input_checkbox'}
 


### PR DESCRIPTION
the basic one is just a simple wrapper around the Action method #double_click

the bang version is a more dumb double click, but more forceful. It opens up double-click-like functionality to objects for which a Selenium::WebDriver::Element is not in scope.
