### PR TITLE
Getting rid of the #present? check.

### DIFF
--- a/lib/selenium_fury/selenium_web_driver/generic_elements/generic_element_helpers.rb
+++ b/lib/selenium_fury/selenium_web_driver/generic_elements/generic_element_helpers.rb
@@ -1,7 +1,6 @@
 module GenericElementHelpers
   def el
-    raise "Locator at #{location} is not present" unless present?
-    @driver.find_element(location)
+    @driver.find_element location
   end
 
   def list


### PR DESCRIPTION
Selenium::WebDriver::Element#find_element already throws an error if a requested element can not be found. But it throws a very informative NoSuchElementErrors error, whereas this #raise was throwing a useless RuntimeError for the exact same situation.

Several methods make assumptions around NoSuchElementErrors. For example Wait#until assumes (correctly) that users want errors raised from an element not being found to be ignored. When using GenericElements in a wait block, however, a user would have to tell Wait#until to ignore StandardErrors as well, because this #present? check was essentially masking NoSuchElementErrors as RuntimeErrors.
